### PR TITLE
Add missing quotes to CLI example

### DIFF
--- a/pages/knowledge/using-email-with-your-vercel-domain.mdx
+++ b/pages/knowledge/using-email-with-your-vercel-domain.mdx
@@ -31,7 +31,7 @@ For ImprovMX, you need to add the following DNS records, replacing `example.com`
 <Snippet dark text="vercel dns add example.com '@' MX mx2.improvmx.com 20" />
 <Caption>Adding an MX record to a custom domain using the Vercel CLI.</Caption>
 
-<Snippet dark text="vercel dns add example.com '@' TXT v=spf1 include:spf.improvmx.com ~all" />
+<Snippet dark text="vercel dns add example.com '@' TXT 'v=spf1 include:spf.improvmx.com ~all'" />
 <Caption>Adding a TXT record to a custom domain using the Vercel CLI.</Caption>
 
 ## Forward Email


### PR DESCRIPTION
Without quotes here, you get an error: "Invalid number of arguments"