### PR TITLE
Fix link to Vercel API section on deployments page

### DIFF
--- a/lib/data/knowledge.json
+++ b/lib/data/knowledge.json
@@ -81,8 +81,7 @@
   },
   {
     "title": "How do I send and receive emails with my Vercel purchased domain?",
-    "description":
-    "Information on how to send and receive email with a domain purchased from Vercel.",
+    "description": "Information on how to send and receive email with a domain purchased from Vercel.",
     "editUrl": "pages/knowledge/using-email-with-your-vercel-domain.mdx",
     "url": "/knowledge/using-email-with-your-vercel-domain",
     "published": "2020-05-18T18:54:36.000Z",

--- a/pages/docs/v2/platform/deployments.mdx
+++ b/pages/docs/v2/platform/deployments.mdx
@@ -15,7 +15,7 @@ export const meta = {
   title: 'Deployments',
   description: `Understanding and making deployments with ${PRODUCT_NAME}.`,
   editUrl: 'pages/docs/v2/platform/deployments.mdx',
-  lastEdited: '2020-05-14T23:00:11.000Z'
+  lastEdited: '2020-05-30T04:40:07.000Z'
 }
 
 A deployment is the result of building your [Project](/docs/v2/platform/projects/) and making it available through a live URL.
@@ -24,7 +24,7 @@ This section contains information about making, managing, and understanding the 
 
 ## Making Deployments
 
-There are multiple ways to make deployments with <ProductName />; these include via a [<ProductName /> for Git Integration](#git-integration), [Deploy Hooks](#deploy-hooks), [<ProductShortName /> CLI](#vercel-cli), and the [<ProductName /> API](#now-api).
+There are multiple ways to make deployments with <ProductName />; these include via a [<ProductName /> for Git Integration](#git-integration), [Deploy Hooks](#deploy-hooks), [<ProductShortName /> CLI](#vercel-cli), and the [<ProductName /> API](#vercel-api).
 
 When making deployments, the [Project](/docs/v2/platform/projects/) will be uploaded and transformed into a production-ready output through the use of a [Build Step](/docs/v2/build-step).
 


### PR DESCRIPTION
The link now correctly jumps down to the Vercel API section on the deployments page.

Problem can be seen in the first sentence of [Making Deployments](https://vercel.com/docs/v2/platform/deployments#making-deployments), "Vercel API" doesn't link to the section below.