### PR TITLE
KB - Update A Record Verification

### DIFF
--- a/lib/data/knowledge.json
+++ b/lib/data/knowledge.json
@@ -8,18 +8,18 @@
     "lastEdited": "2020-06-18T13:46:54.155Z"
   },
   {
-    "title": "Can I Use My Domain on Vercel with A Records?",
-    "description": "Information on how to use A records with Vercel to verify a domain.",
-    "editUrl": "pages/knowledge/a-record-and-caa-with-vercel.mdx",
-    "url": "/knowledge/a-record-and-caa-with-vercel",
-    "published": "2020-06-17T13:46:54.155Z",
-    "lastEdited": "2020-06-15T13:46:54.155Z"
-  },
-  {
     "title": "Can I Add Nameserver Records to Subdomains on Vercel?",
     "description": "Information about subzone delegation when using Nameservers managed by Vercel.",
     "editUrl": "pages/knowledge/can-i-add-nameservers-to-subdomains.mdx",
     "url": "/knowledge/can-i-add-nameservers-to-subdomains",
+    "published": "2020-06-17T13:46:54.155Z",
+    "lastEdited": "2020-06-15T13:46:54.155Z"
+  },
+  {
+    "title": "Can I Verify My Domain on Vercel with A Records?",
+    "description": "Information on how to use A records with Vercel to verify a domain.",
+    "editUrl": "pages/knowledge/verifying-domains-with-a-records.mdx",
+    "url": "/knowledge/verifying-domains-with-a-records",
     "published": "2020-06-17T13:46:54.155Z",
     "lastEdited": "2020-06-15T13:46:54.155Z"
   },

--- a/pages/knowledge/verifying-domains-with-a-records.mdx
+++ b/pages/knowledge/verifying-domains-with-a-records.mdx
@@ -1,11 +1,12 @@
 import Layout from '~/components/layout/knowledge'
+import Note from '~/components/text/note'
 
 export const meta = {
-  title: 'Can I Use My Domain on Vercel with A Records?',
+  title: 'Can I Verify My Domain on Vercel with A Records?',
   description:
     'Information on how to use A records with Vercel to verify a domain.',
-  editUrl: 'pages/knowledge/a-record-and-caa-with-vercel.mdx',
-  url: '/knowledge/a-record-and-caa-with-vercel',
+  editUrl: 'pages/knowledge/verifying-domains-with-a-records.mdx',
+  url: '/knowledge/verifying-domains-with-a-records',
   published: '2020-06-17T13:46:54.155Z',
   lastEdited: '2020-06-15T13:46:54.155Z'
 }
@@ -14,12 +15,16 @@ Vercel is currently testing the [Anycast methodology](https://en.wikipedia.org/w
 
 ## Verifying with A Records
 
-To verify the domain, add the following records with your DNS provider:
+To verify the domain, add the following record with your DNS provider:
 
 - An A record with the value `76.76.21.21`.
-- A CAA record on the root of your domain with the value `"0 issue letsencrypt.org"`.
 
 If you followed the instructions above successfully, your domain will be available for use on any Vercel project that you own. All that's required is to add it to the project you wish to use it with.
+
+<Note type="warning">
+  If a CAA record is preent prior to the addition of the A record, this will
+  need to be removed to allow Vercel to issue a certificate.
+</Note>
 
 export default ({ children }) => <Layout meta={meta}>{children}</Layout>
 


### PR DESCRIPTION
This PR updates the instructions and title for verifying a domain on Vercel using an A record.

It removes the CAA record addition and advises that if a conflicting CAA exists, this will need to be removed.