### PR TITLE
Add Environment Variables for Deploy Button

### DIFF
--- a/components/buttons/deploy.js
+++ b/components/buttons/deploy.js
@@ -3,11 +3,24 @@ import Button from './button'
 
 const VERCEL_EXAMPLES_URL = 'github.com/vercel/vercel/tree/master/examples/'
 
-export default function DeployButton({ url }) {
+export default function DeployButton({ env, envDescription, envLink, url }) {
+  const formatEnv = () => {
+    const envListFormatted = env ? `&env=${env.toString()}` : ''
+    const envDescriptionFormatted = envDescription
+      ? `&envDescription=${envDescription}`
+      : ''
+    const envLinkFormatted = envLink ? `&envLink=${envLink}` : ''
+
+    const envString =
+      envLinkFormatted + envDescriptionFormatted + envListFormatted
+
+    return envString
+  }
+
   const deployUrl = url.includes(VERCEL_EXAMPLES_URL)
     ? `https://vercel.com/import/${url.split(VERCEL_EXAMPLES_URL)[1]}`
     : url.startsWith('http://') || url.startsWith('https://')
-    ? `https://vercel.com/import/project?template=${url}`
+    ? `https://vercel.com/import/git?s=${url}${formatEnv()}`
     : `https://vercel.com/import/${url}`
 
   return (

--- a/components/buttons/deploy.js
+++ b/components/buttons/deploy.js
@@ -5,7 +5,12 @@ const VERCEL_EXAMPLES_URL = 'github.com/vercel/vercel/tree/master/examples/'
 
 export default function DeployButton({ env, envDescription, envLink, url }) {
   const formatEnv = () => {
-    const envListFormatted = env ? `&env=${env.toString()}` : ''
+    const envListFormatted =
+      env.filter(Boolean).length >= 2
+        ? `&env=${env.filter(Boolean).join(',')}`
+        : env[0] !== ''
+        ? `&env=${env[0]}`
+        : ''
     const envDescriptionFormatted = envDescription
       ? `&envDescription=${envDescription}`
       : ''

--- a/components/buttons/deploy.js
+++ b/components/buttons/deploy.js
@@ -4,13 +4,15 @@ import Button from './button'
 const VERCEL_EXAMPLES_URL = 'github.com/vercel/vercel/tree/master/examples/'
 
 export default function DeployButton({ env, envDescription, envLink, url }) {
+  console.log('ENV', env)
   const formatEnv = () => {
-    const envListFormatted =
-      env && env.filter(Boolean).length >= 2
+    const envListFormatted = env
+      ? env.filter(Boolean).length >= 2
         ? `&env=${env.filter(Boolean).join(',')}`
         : env[0] !== ''
         ? `&env=${env[0]}`
         : ''
+      : ''
     const envDescriptionFormatted = envDescription
       ? `&envDescription=${envDescription}`
       : ''

--- a/components/buttons/deploy.js
+++ b/components/buttons/deploy.js
@@ -5,7 +5,7 @@ const VERCEL_EXAMPLES_URL = 'github.com/vercel/vercel/tree/master/examples/'
 
 export default function DeployButton({ env, envDescription, envLink, url }) {
   const formatEnv = () => {
-    const envListFormatted = env ? `&env=${env.toString()}` : ''
+    const envListFormatted = env.filter(Boolean).length >= 2 ? `&env=${env.filter(Boolean).join(',')}` : env[0] !== '' ? `&env=${env[0]}` : ''
     const envDescriptionFormatted = envDescription
       ? `&envDescription=${envDescription}`
       : ''

--- a/components/buttons/deploy.js
+++ b/components/buttons/deploy.js
@@ -6,7 +6,7 @@ const VERCEL_EXAMPLES_URL = 'github.com/vercel/vercel/tree/master/examples/'
 export default function DeployButton({ env, envDescription, envLink, url }) {
   const formatEnv = () => {
     const envListFormatted =
-      env.filter(Boolean).length >= 2
+      env && env.filter(Boolean).length >= 2
         ? `&env=${env.filter(Boolean).join(',')}`
         : env[0] !== ''
         ? `&env=${env[0]}`

--- a/components/buttons/deploy.js
+++ b/components/buttons/deploy.js
@@ -5,7 +5,7 @@ const VERCEL_EXAMPLES_URL = 'github.com/vercel/vercel/tree/master/examples/'
 
 export default function DeployButton({ env, envDescription, envLink, url }) {
   const formatEnv = () => {
-    const envListFormatted = env.filter(Boolean).length >= 2 ? `&env=${env.filter(Boolean).join(',')}` : env[0] !== '' ? `&env=${env[0]}` : ''
+    const envListFormatted = env ? `&env=${env.toString()}` : ''
     const envDescriptionFormatted = envDescription
       ? `&envDescription=${envDescription}`
       : ''

--- a/components/buttons/deploy.js
+++ b/components/buttons/deploy.js
@@ -4,7 +4,6 @@ import Button from './button'
 const VERCEL_EXAMPLES_URL = 'github.com/vercel/vercel/tree/master/examples/'
 
 export default function DeployButton({ env, envDescription, envLink, url }) {
-  console.log('ENV', env)
   const formatEnv = () => {
     const envListFormatted = env
       ? env.filter(Boolean).length >= 2

--- a/components/deploy-banner/index.js
+++ b/components/deploy-banner/index.js
@@ -2,7 +2,13 @@ import Note from '~/components/text/note'
 import { DeployButton } from '~/components/buttons'
 import Link from '~/components/text/link'
 
-export default function DeployBanner({ example, demo }) {
+export default function DeployBanner({
+  env,
+  envDescription,
+  envLink,
+  example,
+  demo
+}) {
   return (
     <div className="deploy-banner">
       <Note label={false}>
@@ -12,7 +18,12 @@ export default function DeployBanner({ example, demo }) {
             {demo}
           </Link>
         </span>
-        <DeployButton url={example} />
+        <DeployButton
+          env={env}
+          envDescription={envDescription}
+          envLink={envLink}
+          url={example}
+        />
       </Note>
       <style jsx>{`
         .deploy-banner {

--- a/components/guides/deploy-section/index.js
+++ b/components/guides/deploy-section/index.js
@@ -19,7 +19,12 @@ export default function DeploySection({ meta }) {
             button, and create a Git repository for it in the process for
             automatic deployments for your updates.
           </p>
-          <DeployButton url={meta.example} />
+          <DeployButton
+            env={meta.env}
+            envDescription={meta.envDescription}
+            envLink={meta.envLink}
+            url={meta.example}
+          />
         </>
       )}
       <style jsx>{`

--- a/components/layout/guide.js
+++ b/components/layout/guide.js
@@ -93,7 +93,13 @@ class Guide extends React.PureComponent {
             <Wrapper width="768">
               <section className="guide content">
                 {meta.example && meta.demo && (
-                  <DeployBanner example={meta.example} demo={meta.demo} />
+                  <DeployBanner
+                    env={meta.env}
+                    envDescription={meta.envDescription}
+                    envLink={meta.envLink}
+                    example={meta.example}
+                    demo={meta.demo}
+                  />
                 )}
                 {this.props.children}
                 <NonAmpOnly>

--- a/lib/data/guides.json
+++ b/lib/data/guides.json
@@ -220,12 +220,15 @@
     "authors": ["coetry"],
     "url": "/guides/deploying-next-and-userbase-with-vercel",
     "env": ["NEXT_PUBLIC_USERBASE_APP_ID"],
+    "envDescription": ["The Userbase app ID, found in the Userbase dashboard."],
+    "envLink": ["https://v1.userbase.com/"],
     "image": "https://assets.zeit.co/image/upload/v1587744671/twitter-cards/next_userbase_vercel_og_image.png",
     "editUrl": "pages/guides/deploying-next-and-userbase-with-vercel.mdx",
+    "example": "https://github.com/vercel/next.js/tree/canary/examples/with-userbase",
     "demo": "https://next-userbase.vercel.app",
     "name": "Next.js + Userbase",
     "type": "app",
-    "lastEdited": "2020-07-15T14:18:08.000Z"
+    "lastEdited": "2020-07-15T15:03:40.000Z"
   },
   {
     "title": "Debug and Troubleshoot Logs with Vercel and Sematext",

--- a/pages/guides/deploying-next-and-userbase-with-vercel.mdx
+++ b/pages/guides/deploying-next-and-userbase-with-vercel.mdx
@@ -16,13 +16,17 @@ export const meta = {
   authors: ['coetry'],
   url: '/guides/deploying-next-and-userbase-with-vercel',
   env: ['NEXT_PUBLIC_USERBASE_APP_ID'],
+  envDescription: ['The Userbase app ID, found in the Userbase dashboard.'],
+  envLink: ['https://v1.userbase.com/'],
   image:
     'https://assets.zeit.co/image/upload/v1587744671/twitter-cards/next_userbase_vercel_og_image.png',
   editUrl: 'pages/guides/deploying-next-and-userbase-with-vercel.mdx',
+  example:
+    'https://github.com/vercel/next.js/tree/canary/examples/with-userbase',
   demo: 'https://next-userbase.vercel.app',
   name: 'Next.js + Userbase',
   type: 'app',
-  lastEdited: '2020-07-15T14:18:08.000Z'
+  lastEdited: '2020-07-15T15:03:40.000Z'
 }
 
 [Userbase](https://userbase.com/) is the easiest way to add user accounts and data persistence to your static site.


### PR DESCRIPTION
This PR adds the ability to pass the following environment variable details when using the deploy button:

- `env` (String [] - a list of environment variable names required)
- `envDescription` (String - a description of the environment variables required)
- `envLink` (String - a link to 'learn more' about the environment required)

All properties are optional and provided for guides using the same properties names in the `meta` object.

![image](https://user-images.githubusercontent.com/26944716/87562409-e87b5b00-c6b5-11ea-8047-b50862fd5f06.png)

This can be tested using the Next.js + Userbase guide (link added on deployment).

Based on the image, some minor padding adjustments can be made to front to handle the description and link a little better.