### PR TITLE
Add RedwoodJS Guide

### DIFF
--- a/lib/data/guides.json
+++ b/lib/data/guides.json
@@ -239,6 +239,20 @@
     "rank": 25
   },
   {
+    "title": "Deploy RedwoodJS with Vercel",
+    "description": "Create a Redwood app and deploy it live with Vercel.",
+    "published": "2020-08-18T12:00:00.860Z",
+    "authors": ["mcsdev"],
+    "url": "/guides/deploying-redwood-with-vercel",
+    "image": "https://og-image.now.sh/**Deploy%20RedwoodJS%20Apps**%20%3Cbr%2F%3E%20with%20Vercel.png?theme=light&md=1&fontSize=100px&images=https%3A%2F%2Fassets.vercel.com%2Fimage%2Fupload%2Ffront%2Fassets%2Fdesign%2Fvercel-triangle-black.svg&images=https%3A%2F%2Fd33wubrfki0l68.cloudfront.net%2F492ed629970792d32ac857da0166a7d2308bad99%2F428b6%2Fimages%2Fdiecut.svg&widths=300&widths=350&heights=300&heights=350",
+    "name": "Redwood",
+    "type": "app",
+    "editUrl": "pages/guides/deploying-redwood-with-vercel.mdx",
+    "example": "https://github.com/vercel/vercel/tree/master/examples/redwoodjs",
+    "demo": "https://redwoodjs-example.vercel.app",
+    "lastEdited": "2020-08-18T10:32:05.000Z"
+  },
+  {
     "title": "Deploy Next.js and Userbase with Vercel",
     "description": "Create a Todo app with Next.js and Userbase and deploy it live with Vercel.",
     "published": "2020-07-15T12:00:00.860Z",
@@ -421,9 +435,9 @@
     "url": "/guides/deploying-stencil-with-vercel",
     "example": "stencil",
     "demo": "https://stencil.now-examples.now.sh",
-    "image": "https://og-image.now.sh/**Deploy%20Stencil%20Apps**%20%3Cbr%2F%3E%20with%20Vercel.png?theme=light&md=1&fontSize=100px&images=https%3A%2F%2Fassets.vercel.com%2Fimage%2Fupload%2Ffront%2Fassets%2Fdesign%2Fzeit-black-triangle.svg&images=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAARMAAAC3CAMAAAAGjUrGAAAAclBMVEX%2F%2F%2F8AAACTk5PBwcEiIiL6%2Bvrq6up0dHTz8%2FNjY2NNTU04ODjFxcXf39%2FT09MfHx%2BKioqenp6ysrLNzc24uLh%2Ff39qamrl5eWsrKwICAibm5sxMTE%2FPz9dXV3a2toZGRlWVlZGRkYrKys7Ozt3d3eEhIQ8LwBQAAAD4UlEQVR4nO2dW1YqURBDQWjFB4Ig4gMUUOc%2FxTuA%2BivuNmSt7BkkX5WunK7R6C8ZPhZTiPHTnyr5bwynMcZGLa7JkbPkVq2tyS1nyZ1aW5MbzpJ7tbYmS86SxaAW1%2BOJs2R8rRbXYwVaMleL6%2FEAWvKoFtfjEbRkohbXYwtaslKL6zEDLXlXi%2BsxvHGW%2FKrFNfngLLlRa2tyx1lyUGtr8sJZslNra7LhLJmaTvRXnCXjmVpcj1fQkq1aXI9n0BLTiX4NWvKgFtfjE7TEdKK%2FBi1x%2FUYPTvRLtbgmU84S14l%2Bx1myV2trsucsOaq1NQHXFie1tibg2sJ1os%2FaokCuLT7V4nqQa4u1WlwPcm3xrBbXg1xbvKrF9SDXFldqcT2GBWfJj1pcE3Bt4VpEAtcWrkUkcG3xodbWBFxbfJlO9OTawnSiJ9cWpkWkCWiJ6URPri1MJ3pybWE60ZNrC9Mi0uyLs8T1aQH42uJFra0JuLY4qLU1AdcW32ptTcC1hevTgqwtCuTawrSIRIYc0yLSaMJhuskJIYQQQgiXy3x5ZcuSiQzXYEMah%2FlwNwMb0jhMO2G4V%2Bs6A6idAPYpcO6ZD3fgv25wFsyHO%2FDrKw%2FTTiC%2FvuIw7YR3taxzYAYTsjSOwzyqJEvjOExhgyyN4zCPKudqWefAPKq0DjnMo8qEnEJCTiUhp%2BAccqYJOQUm5PyqZZ1DQk4hIaeQkFNIyCkk5BSgkKOWdQ4JOYWEnEJCTiEhp5BNTiWbnAITcsgePU5CTiEhp5CQU0jIKWSTU0jIKSTkFBJyCgk5hYScSkJOISGnwIQc8moBTkJOISGnkJBTYK56JeQUEnIKCTmVhJzCQa3rDKC62tr5GajpH0NDCCGEEMLlAv7kb6LW1oRcAph6Qi4BTP%2FuTi4BTC%2BwkjcATO81kTcATO81kW8XTO81zcAlgOm9pgG86uV6rwn84u36d3ew1vNm%2BvX1h7PE9V4TedXL9O%2Fu5A%2FvmYoJDjnRr9TiepATvWnIITssTI8eh5zomYoJDnnVa68W1wTssBzV2pqAE71ryAHv9LoepQXv9LqGHPL%2FQqYhJyesCuSdXtNNDtlKNw05W9AS05AzAy1hevQ4w4KzxDTkkEdpXUMOWMHeqbU1ASf6k1pbE%2FCPodBjYRyyYmIacsif6ZheYCXfma7V4nqQFRPTkEN%2BkH5Vi%2BtBTvTvanE9hhNniWnIGR05S5gDfjx7zpKDWlsT8M8xriEHLI27hhxwonfd5JAVE9OQQ1ZMTEMOOdGbhhxyojcNOWTFxDTkjMDSuGnIISsmG7W2JmBp3DXk%2FI6nEF8X9ibnH2mNa2xGXo7jAAAAAElFTkSuQmCC",
+    "image": "https://og-image.now.sh/**Deploy%20RedwoodJS%20Apps**%20%3Cbr%2F%3E%20with%20Vercel.png?theme=light&md=1&fontSize=100px&images=https%3A%2F%2Fassets.vercel.com%2Fimage%2Fupload%2Ffront%2Fassets%2Fdesign%2Fvercel-triangle-black.svg&images=https%3A%2F%2Fd33wubrfki0l68.cloudfront.net%2F492ed629970792d32ac857da0166a7d2308bad99%2F428b6%2Fimages%2Fdiecut.svg&widths=300&widths=350&heights=300&heights=350",
     "editUrl": "pages/guides/deploying-stencil-with-vercel.mdx",
-    "lastEdited": "2020-07-17T05:49:23.000Z"
+    "lastEdited": "2020-08-18T10:32:05.000Z"
   },
   {
     "title": "Deploy Saber with Vercel",

--- a/pages/guides/deploying-redwood-with-vercel.mdx
+++ b/pages/guides/deploying-redwood-with-vercel.mdx
@@ -1,0 +1,99 @@
+import Guide from '~/components/layout/guide'
+import Snippet from '~/components/snippet'
+import Caption from '~/components/text/caption'
+import Link from '~/components/text/link'
+import Note from '~/components/text/note'
+import { InlineCode } from '~/components/text/code'
+import DeploySection from '~/components/guides/deploy-section'
+import { PRODUCT_NAME } from '~/lib/constants'
+import NameWrapper from '~/components/name/name-wrapper'
+
+export const meta = {
+  title: `Deploy RedwoodJS with ${PRODUCT_NAME}`,
+  description: `Create a Redwood app and deploy it live with ${PRODUCT_NAME}.`,
+  published: '2020-08-18T12:00:00.860Z',
+  authors: ['mcsdev'],
+  url: '/guides/deploying-redwood-with-vercel',
+  image: `https://og-image.now.sh/**Deploy%20RedwoodJS%20Apps**%20%3Cbr%2F%3E%20with%20Vercel.png?theme=light&md=1&fontSize=100px&images=https%3A%2F%2Fassets.vercel.com%2Fimage%2Fupload%2Ffront%2Fassets%2Fdesign%2Fvercel-triangle-black.svg&images=https%3A%2F%2Fd33wubrfki0l68.cloudfront.net%2F492ed629970792d32ac857da0166a7d2308bad99%2F428b6%2Fimages%2Fdiecut.svg&widths=300&widths=350&heights=300&heights=350`,
+  name: 'Redwood',
+  type: 'app',
+  editUrl: 'pages/guides/deploying-redwood-with-vercel.mdx',
+  example: 'https://github.com/vercel/vercel/tree/master/examples/redwoodjs',
+  demo: 'https://redwoodjs-example.vercel.app',
+  lastEdited: '2020-08-18T10:32:05.000Z',
+}
+
+[RedwoodJS](https://redwoodjs.com/) is an opinionated, full-stack, serverless web application framework that will allow you to build and deploy JAMstack applications with ease.
+
+In this guide, you will discover how to create and deploy a Redwood app to [Vercel](/), with the option to provide a connection string to persist app data with a database connection.
+
+## Step 1: Creating Your Redwood App
+
+Set up a new Redwood app by initializing the project template with [npm](https://www.npmjs.com/):
+
+<Snippet dark text="npm init redwood-app ./my-redwood-app" />
+<Caption>Initializing a Redwood app with npm.</Caption>
+
+Locate the `redwood.toml` file and change the `apiProxyPath` to `"/api"`. Your `redwood.toml` will look like this:
+
+```json
+[web]
+  port = 8910
+  apiProxyPath = "/api"
+[api]
+  port = 8911
+[browser]
+  open = true
+```
+
+<Caption>
+  The <InlineCode>redwood.toml</InlineCode> file with an updated{' '}
+  <InlineCode>apiProxyPath</InlineCode> set.
+</Caption>
+
+## Step 2: Add a Connection String (Optional)
+
+If you do not wish to use a database to persist app data, you can skip this step and continue to [step 3](#step-3:-deploy-your-app-with-vercel).
+
+In the `api/prisma/schema.prisma` file, ensure that the database provider is set to the one you are using, for example:
+
+```bash
+datasource DS {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+```
+
+<Caption>
+  The <InlineCode>api/prisma/schema.prisma</InlineCode> file with the{' '}
+  <InlineCode>provider</InlineCode> set to <InlineCode>postgresql</InlineCode>.
+</Caption>
+
+Update the `.env` file with your database connection string. Once set, this will allow you to develop your app locally with a database connected.
+
+When [importing the project](/docs/git-integrations) into Vercel, you will be provided with the option to specify [environment variables](/docs/build-step#environment-variables). Make sure to add a `DATABASE_URL` environment variable with the connection string used.
+
+After adding the environment variables during the import process, you can manage them from the Vercel Dashboard. To keep them in sync with your local environment, use the following command:
+
+<Snippet dark text="vercel env pull" />
+<Caption>
+  Pulling the latest environment variables set in the Vercel Dashboard.
+</Caption>
+
+<Note>
+  You can find more information on using a database with Redwood in the{' '}
+  <Link href="https://redwoodjs.com/docs/deploy#prisma-and-database">
+    Redwood documentation
+  </Link>
+  .
+</Note>
+
+## Step 3: Deploy Your App with <NameWrapper name={PRODUCT_NAME} />
+
+<DeploySection meta={meta} />
+
+export default ({ children }) => <Guide meta={meta}>{children}</Guide>
+
+export const config = {
+  amp: 'hybrid',
+}

--- a/pages/guides/deploying-stencil-with-vercel.mdx
+++ b/pages/guides/deploying-stencil-with-vercel.mdx
@@ -18,9 +18,9 @@ export const meta = {
   url: '/guides/deploying-stencil-with-vercel',
   example: 'stencil',
   demo: 'https://stencil.now-examples.now.sh',
-  image: `https://og-image.now.sh/**Deploy%20Stencil%20Apps**%20%3Cbr%2F%3E%20with%20${PRODUCT_NAME}.png?theme=light&md=1&fontSize=100px&images=https%3A%2F%2Fassets.vercel.com%2Fimage%2Fupload%2Ffront%2Fassets%2Fdesign%2Fzeit-black-triangle.svg&images=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAARMAAAC3CAMAAAAGjUrGAAAAclBMVEX%2F%2F%2F8AAACTk5PBwcEiIiL6%2Bvrq6up0dHTz8%2FNjY2NNTU04ODjFxcXf39%2FT09MfHx%2BKioqenp6ysrLNzc24uLh%2Ff39qamrl5eWsrKwICAibm5sxMTE%2FPz9dXV3a2toZGRlWVlZGRkYrKys7Ozt3d3eEhIQ8LwBQAAAD4UlEQVR4nO2dW1YqURBDQWjFB4Ig4gMUUOc%2FxTuA%2BivuNmSt7BkkX5WunK7R6C8ZPhZTiPHTnyr5bwynMcZGLa7JkbPkVq2tyS1nyZ1aW5MbzpJ7tbYmS86SxaAW1%2BOJs2R8rRbXYwVaMleL6%2FEAWvKoFtfjEbRkohbXYwtaslKL6zEDLXlXi%2BsxvHGW%2FKrFNfngLLlRa2tyx1lyUGtr8sJZslNra7LhLJmaTvRXnCXjmVpcj1fQkq1aXI9n0BLTiX4NWvKgFtfjE7TEdKK%2FBi1x%2FUYPTvRLtbgmU84S14l%2Bx1myV2trsucsOaq1NQHXFie1tibg2sJ1os%2FaokCuLT7V4nqQa4u1WlwPcm3xrBbXg1xbvKrF9SDXFldqcT2GBWfJj1pcE3Bt4VpEAtcWrkUkcG3xodbWBFxbfJlO9OTawnSiJ9cWpkWkCWiJ6URPri1MJ3pybWE60ZNrC9Mi0uyLs8T1aQH42uJFra0JuLY4qLU1AdcW32ptTcC1hevTgqwtCuTawrSIRIYc0yLSaMJhuskJIYQQQgiXy3x5ZcuSiQzXYEMah%2FlwNwMb0jhMO2G4V%2Bs6A6idAPYpcO6ZD3fgv25wFsyHO%2FDrKw%2FTTiC%2FvuIw7YR3taxzYAYTsjSOwzyqJEvjOExhgyyN4zCPKudqWefAPKq0DjnMo8qEnEJCTiUhp%2BAccqYJOQUm5PyqZZ1DQk4hIaeQkFNIyCkk5BSgkKOWdQ4JOYWEnEJCTiEhp5BNTiWbnAITcsgePU5CTiEhp5CQU0jIKWSTU0jIKSTkFBJyCgk5hYScSkJOISGnwIQc8moBTkJOISGnkJBTYK56JeQUEnIKCTmVhJzCQa3rDKC62tr5GajpH0NDCCGEEMLlAv7kb6LW1oRcAph6Qi4BTP%2FuTi4BTC%2BwkjcATO81kTcATO81kW8XTO81zcAlgOm9pgG86uV6rwn84u36d3ew1vNm%2BvX1h7PE9V4TedXL9O%2Fu5A%2FvmYoJDjnRr9TiepATvWnIITssTI8eh5zomYoJDnnVa68W1wTssBzV2pqAE71ryAHv9LoepQXv9LqGHPL%2FQqYhJyesCuSdXtNNDtlKNw05W9AS05AzAy1hevQ4w4KzxDTkkEdpXUMOWMHeqbU1ASf6k1pbE%2FCPodBjYRyyYmIacsif6ZheYCXfma7V4nqQFRPTkEN%2BkH5Vi%2BtBTvTvanE9hhNniWnIGR05S5gDfjx7zpKDWlsT8M8xriEHLI27hhxwonfd5JAVE9OQQ1ZMTEMOOdGbhhxyojcNOWTFxDTkjMDSuGnIISsmG7W2JmBp3DXk%2FI6nEF8X9ibnH2mNa2xGXo7jAAAAAElFTkSuQmCC`,
+  image: `https://og-image.now.sh/**Deploy%20RedwoodJS%20Apps**%20%3Cbr%2F%3E%20with%20Vercel.png?theme=light&md=1&fontSize=100px&images=https%3A%2F%2Fassets.vercel.com%2Fimage%2Fupload%2Ffront%2Fassets%2Fdesign%2Fvercel-triangle-black.svg&images=https%3A%2F%2Fd33wubrfki0l68.cloudfront.net%2F492ed629970792d32ac857da0166a7d2308bad99%2F428b6%2Fimages%2Fdiecut.svg&widths=300&widths=350&heights=300&heights=350`,
   editUrl: 'pages/guides/deploying-stencil-with-vercel.mdx',
-  lastEdited: '2020-07-17T05:49:23.000Z'
+  lastEdited: '2020-08-18T10:32:05.000Z',
 }
 
 [Stencil](https://stenciljs.com/) is a toolchain for building reusable, scalable Design Systems. Generate small, blazing fast, and 100% standards based Web Components that run in every browser.
@@ -29,8 +29,11 @@ export const meta = {
 
 Set up a Stencil app with [`npm`](https://www.npmjs.com/) and move into the project directory, choosing the option **ionic-pwa** and providing the name **my-stencil-project**:
 
-<Snippet width="100%"dark text="npm init stencil && cd my-stencil-project" />
-<Caption>Initializing a Stencil app with <Link href="https://www.npmjs.com/">npm</Link> and moving into the project directory.</Caption>
+<Snippet width="100%" dark text="npm init stencil && cd my-stencil-project" />
+<Caption>
+  Initializing a Stencil app with <Link href="https://www.npmjs.com/">npm</Link>{' '}
+  and moving into the project directory.
+</Caption>
 
 ## Step 2: Deploying Your Stencil App with <NameWrapper name={PRODUCT_NAME} />
 
@@ -39,5 +42,5 @@ Set up a Stencil app with [`npm`](https://www.npmjs.com/) and move into the proj
 export default ({ children }) => <Guide meta={meta}>{children}</Guide>
 
 export const config = {
-  amp: 'hybrid'
+  amp: 'hybrid',
 }


### PR DESCRIPTION
This PR adds a RedwoodJS guide complete with an example.

Before merging, changes need to be made to the `<Snippet>` component for the layout of the guide, as this is not functioning correctly.